### PR TITLE
Upgrade to zig 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ like this:
     $ git submodule init
     $ git submodule update
 
-Then [download zig 0.8.1](https://ziglang.org/download/) and move it to
+Then [download zig 0.9.0](https://ziglang.org/download/) and move it to
 the `curses-minesweeper` directory, and run this:
 
     $ tar xf zig-linux-SOMETHING.tar.xz         (use autocompletion)

--- a/src/argparser.zig
+++ b/src/argparser.zig
@@ -20,7 +20,7 @@ fn parseSize(str: []const u8, width: *u8, height: *u8) !void {
     }
 }
 
-pub fn parse(allocator: *std.mem.Allocator) !Args {
+pub fn parse() !Args {
     const params = comptime [_]clap.Param(clap.Help) {
         clap.parseParam("-h, --help                 Display this help and exit") catch unreachable,
         clap.parseParam("-s, --size <STR>           How big to make minesweeper, e.g. 15x15") catch unreachable,
@@ -52,7 +52,7 @@ pub fn parse(allocator: *std.mem.Allocator) !Args {
         std.os.exit(0);
     }
     if (args.option("--size")) |size| {
-        parseSize(size, &result.width, &result.height) catch |err| {
+        parseSize(size, &result.width, &result.height) catch {
             try std.io.getStdErr().writer().print(
                 "{s}: invalid minesweeper size \"{s}\"",
                 .{ std.process.args().nextPosix().?, size });

--- a/src/core.zig
+++ b/src/core.zig
@@ -17,16 +17,16 @@ pub const SquareInfo = struct {
 pub const GameStatus = enum { PLAY, WIN, LOSE };
 
 pub const Game = struct {
-    allocator: *std.mem.Allocator,
+    allocator: std.mem.Allocator,
     map: [][]Square,
     width: u8,
     height: u8,
     nmines: u16,
     status: GameStatus,
     mines_added: bool,
-    rnd: *std.rand.Random,
+    rnd: *const std.rand.Random,
 
-    pub fn init(allocator: *std.mem.Allocator, width: u8, height: u8, nmines: u16, rnd: *std.rand.Random) !Game {
+    pub fn init(allocator: std.mem.Allocator, width: u8, height: u8, nmines: u16, rnd: *const std.rand.Random) !Game {
         // in the beginning, there are width*height squares, but the mines are
         // added when the user has already opened one of them, otherwise the
         // first square that the user opens could be a mine

--- a/src/curses.zig
+++ b/src/curses.zig
@@ -23,7 +23,7 @@ pub const KEY_DOWN: c_int = c.KEY_DOWN;
 
 pub const Window = struct {
     win: *c.WINDOW,
-    allocator: *std.mem.Allocator,
+    allocator: std.mem.Allocator,
 
     // TODO: change more things to Window methods
 
@@ -54,7 +54,7 @@ pub const Window = struct {
 pub const A_STANDOUT = c.MY_A_STANDOUT;
 
 
-pub fn initscr(allocator: *std.mem.Allocator) !Window {
+pub fn initscr(allocator: std.mem.Allocator) !Window {
     const res = c.initscr();
     if (@ptrToInt(res) == 0) {
         return Error;
@@ -79,7 +79,7 @@ pub fn start_color() !void {
     _ = try checkError(c.start_color());
 }
 
-const color_pair_attrs = comptime[_]c_int{
+const color_pair_attrs = [_]c_int{
     -1,                 // 0 doesn't seem to be a valid color pair number, curses returns ERR for it
     c.MY_COLOR_PAIR_1,
     c.MY_COLOR_PAIR_2,

--- a/src/cursesui.zig
+++ b/src/cursesui.zig
@@ -123,7 +123,7 @@ pub const Ui = struct {
         try self.window.mvaddstr(y, x, right);
     }
 
-    fn drawGrid(self: *const Ui, allocator: *std.mem.Allocator) !void {
+    fn drawGrid(self: *const Ui) !void {
         var top: u16 = (self.window.getmaxy() - self.getHeight()) / 2;
         var left: u16 = (self.window.getmaxx() - self.getWidth()) / 2;
 
@@ -203,8 +203,8 @@ pub const Ui = struct {
         try self.window.attroff(curses.A_STANDOUT);
     }
 
-    pub fn draw(self: *Ui, allocator: *std.mem.Allocator) !void {
-        try self.drawGrid(allocator);
+    pub fn draw(self: *Ui) !void {
+        try self.drawGrid();
 
         if (self.status_message == null) {
             switch(self.game.status) {

--- a/src/help.zig
+++ b/src/help.zig
@@ -48,7 +48,7 @@ const text_with_single_newlines =
     ;
 
 // does nothing to \n\n repeated, but replaces single \n with spaces
-fn removeSingleNewlines(s: []const u8, allocator: *std.mem.Allocator) ![]u8 {
+fn removeSingleNewlines(s: []const u8, allocator: std.mem.Allocator) ![]u8 {
     var result = std.ArrayList(u8).init(allocator);
     errdefer result.deinit();
 
@@ -76,7 +76,7 @@ fn incrementY(window: curses.Window, y: *u16) !void {
     }
 }
 
-fn drawText(window: curses.Window, key_bindings: []const KeyBinding, allocator: *std.mem.Allocator) !void {
+fn drawText(window: curses.Window, key_bindings: []const KeyBinding, allocator: std.mem.Allocator) !void {
     try window.erase();
 
     var maxlen: u16 = 0;
@@ -111,7 +111,7 @@ fn drawText(window: curses.Window, key_bindings: []const KeyBinding, allocator: 
 }
 
 // returns true if ok, false if help message didn't fit on the terminal
-pub fn show(window: curses.Window, key_bindings: []const KeyBinding, allocator: *std.mem.Allocator) !bool {
+pub fn show(window: curses.Window, key_bindings: []const KeyBinding, allocator: std.mem.Allocator) !bool {
     while (true) {
         drawText(window, key_bindings, allocator) catch |err| switch(err) {
             error.TerminalIsTooSmall => return false,     // it might be playable even if help doesn't fit

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,12 +13,12 @@ pub fn main() anyerror!void {
     // displaying unicode characters in curses needs this and cursesw in build.zig
     _ = c_locale.setlocale(c_locale.LC_ALL, "");
 
-    var args = try argparser.parse(allocator);
+    var args = try argparser.parse();
 
     var buf: [8]u8 = undefined;
     try std.os.getrandom(buf[0..]);
     var default_prng = std.rand.DefaultPrng.init(std.mem.readIntSliceLittle(u64, buf[0..]));
-    const rnd = &default_prng.random;
+    const rnd = &default_prng.random();
 
     var game = try core.Game.init(allocator, args.width, args.height, args.nmines, rnd);
     defer game.deinit();
@@ -56,7 +56,7 @@ pub fn main() anyerror!void {
 
     while (true) {
         try stdscr.erase();
-        try ui.draw(allocator);
+        try ui.draw();
 
         switch (try stdscr.getch()) {
             'Q', 'q' => return,


### PR DESCRIPTION
Hello,

Thanks you for writing this minesweeper! I stumbled on this repository while learning about zig and looking for examples. It compiles and works fine on 0.8.1 but not on the latest 0.9.0.

This patch fixes the compilation errors, essentially about https://ziglang.org/download/0.9.0/release-notes.html#Allocgate which changes the way allocators are passed to functions. The other changes are about the strictness of const and unused variables.

Warm regards,