### PR TITLE
Upgrade to Zig 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 valgrind.log
-zig/
 zig-cache/
 zig-out/
+
+# downloaded zig before and after extracting, see README
+zig-*-*-*.tar.xz
+zig/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 valgrind.log
-zig-cache/
+.zig-cache/
 zig-out/
 
 # downloaded zig before and after extracting, see README

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "zig-clap"]
-	path = zig-clap
-	url = https://github.com/Hejsil/zig-clap

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ like this:
     $ git submodule init
     $ git submodule update
 
-Then [download zig 0.9.0](https://ziglang.org/download/) and move it to
+Then [download zig 0.11.0](https://ziglang.org/download/) and move it to
 the `curses-minesweeper` directory, and run this:
 
     $ tar xf zig-linux-SOMETHING.tar.xz         (use autocompletion)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ like this:
     $ git submodule init
     $ git submodule update
 
-Then [download zig 0.11.0](https://ziglang.org/download/) and move it to
+Then [download zig 0.13.0](https://ziglang.org/download/) and move it to
 the `curses-minesweeper` directory, and run this:
 
     $ tar xf zig-linux-SOMETHING.tar.xz         (use autocompletion)
@@ -26,7 +26,7 @@ Now you can compile and run the project.
 
 Run the game:
 
-    $ zig-out/bin/cursesminesweeper
+    $ zig-out/bin/curses-minesweeper
 
 Add `--help` for more options.
 

--- a/build.zig
+++ b/build.zig
@@ -1,28 +1,78 @@
 const std = @import("std");
-const Builder = std.build.Builder;
 
-
-pub fn build(b: *Builder) void {
-    // Mostly copied from https://ziglearn.org/chapter-3/
+pub fn build(b: *std.Build) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
+
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
     const exe = b.addExecutable(.{
-        .name = "cursesminesweeper",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .name = "curses-minesweeper",
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
 
-    exe.linkSystemLibrary("c");
+    exe.linkLibC();
     exe.linkSystemLibrary("ncursesw");
-    //exe.addIncludeDir(".");
+    exe.addIncludePath(b.path("."));
 
-    const zig_clap = b.addModule("zig-clap", .{
-        .source_file = .{ .path = "zig-clap/clap.zig" }
-    });
-    exe.addModule("zig-clap", zig_clap);
-
-    b.default_step.dependOn(&exe.step);
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
     b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+
+    // By making the run step depend on the install step, it will be run from the
+    // installation directory rather than directly from within the cache directory.
+    // This is not necessary, however, if the application depends on other installed
+    // files, this ensures they will be present and in the expected location.
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    // Creates a step for unit testing. This only builds the test executable
+    // but does not run it.
+    const lib_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+
+    const exe_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
+    test_step.dependOn(&run_exe_unit_tests.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -50,29 +50,4 @@ pub fn build(b: *std.Build) void {
     // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
-
-    // Creates a step for unit testing. This only builds the test executable
-    // but does not run it.
-    const lib_unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/root.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-
-    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
-
-    const exe_unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-
-    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
-
-    // Similar to creating the run step earlier, this exposes a `test` step to
-    // the `zig build --help` menu, providing a way for the user to request
-    // running the unit tests.
-    const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&run_lib_unit_tests.step);
-    test_step.dependOn(&run_exe_unit_tests.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -3,18 +3,25 @@ const Builder = std.build.Builder;
 
 
 pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const exe = b.addExecutable("cursesminesweeper", "src/main.zig");
-    exe.setBuildMode(mode);
+    // Mostly copied from https://ziglearn.org/chapter-3/
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "cursesminesweeper",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
     exe.linkSystemLibrary("c");
     exe.linkSystemLibrary("ncursesw");
-    exe.addIncludeDir(".");
-    exe.addPackagePath("zig-clap", "zig-clap/clap.zig");
+    //exe.addIncludeDir(".");
 
-    const run_cmd = exe.run();
-
-    const run_step = b.step("run", "Run the app");
-    run_step.dependOn(&run_cmd.step);
+    const zig_clap = b.addModule("zig-clap", .{
+        .source_file = .{ .path = "zig-clap/clap.zig" }
+    });
+    exe.addModule("zig-clap", zig_clap);
 
     b.default_step.dependOn(&exe.step);
     b.installArtifact(exe);

--- a/src/argparser.zig
+++ b/src/argparser.zig
@@ -20,21 +20,9 @@ fn parseSize(str: []const u8, width: *u8, height: *u8) !void {
     }
 }
 
-pub fn parse() !Args {
-    const params = comptime clap.parseParamsComptime(
-        \\-h, --help                 Display this help and exit
-        \\-s, --size <STR>           How big to make minesweeper, e.g. 15x15
-        \\-n, --mine-count <NUM>     How many mines
-        \\-a, --ascii-only           Use ASCII characters only
-        \\-c, --no-colors            Do not use colors
-    );
-
-    var diag = clap.Diagnostic{};
-    var parse_result = clap.parse(clap.Help, &params, clap.parsers.default, .{ .diagnostic = &diag }) catch |err| {
-        diag.report(std.io.getStdErr().writer(), err) catch {};
-        std.os.exit(2);
-    };
-    defer parse_result.deinit();
+pub fn parse(allocator: std.mem.Allocator) !Args {
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
 
     var result = Args{
         .width = 10,
@@ -44,36 +32,49 @@ pub fn parse() !Args {
         .color = true,
     };
 
-    //if (parse_result.args.help != 0) {
-    //    try std.io.getStdErr().writer().print(
-    //        "Usage: {s} [options]\n\nOptions:\n",
-    //        .{ std.process.parse_result.args().nextPosix().? });
-    //    try clap.help(std.io.getStdErr().writer(), params[0..]);
-    //    std.os.exit(0);
-    //}
-    if (parse_result.args.size) |size| {
-        parseSize(size, &result.width, &result.height) catch {
-            try std.io.getStdErr().writer().print(
-                "{s}: invalid minesweeper size \"{s}\"",
-                .{ std.process.parse_result.args().nextPosix().?, size });
-            std.os.exit(2);
-        };
-    }
-    if (parse_result.args.mine_count) |mineCount| {
-        result.nmines = try std.fmt.parseUnsigned(u8, mineCount, 10);
-    }
-    if (parse_result.args.ascii_only != 0) {
-        result.characters = cursesui.ascii_characters;
-    }
-    if (parse_result.args.no_colors != 0) {
-        result.color = false;
+    var i: usize = 1;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+            std.debug.print("Usage: {s} [options]\n\nOptions:\n", .{args[0]});
+            std.debug.print("  -h, --help               Display this help and exit\n", .{});
+            std.debug.print("  -s, --size <SIZE>        How big to make minesweeper, e.g. 15x15\n", .{});
+            std.debug.print("  -n, --mine-count <NUM>   How many mines\n", .{});
+            std.debug.print("  -a, --ascii-only         Use ASCII characters only\n", .{});
+            std.debug.print("  -c, --no-colors          Do not use colors\n", .{});
+            std.process.exit(0);
+        } else if (std.mem.eql(u8, arg, "-s") or std.mem.eql(u8, arg, "--size")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for size\n", .{});
+                std.process.exit(2);
+            }
+            const size = args[i];
+            parseSize(size, &result.width, &result.height) catch {
+                std.debug.print("Error: Invalid minesweeper size \"{s}\"\n", .{size});
+                std.process.exit(2);
+            };
+        } else if (std.mem.eql(u8, arg, "-n") or std.mem.eql(u8, arg, "--mine-count")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for mine count\n", .{});
+                std.process.exit(2);
+            }
+            const mineCount = args[i];
+            result.nmines = try std.fmt.parseUnsigned(u16, mineCount, 10);
+        } else if (std.mem.eql(u8, arg, "-a") or std.mem.eql(u8, arg, "--ascii-only")) {
+            result.characters = cursesui.ascii_characters;
+        } else if (std.mem.eql(u8, arg, "-c") or std.mem.eql(u8, arg, "--no-colors")) {
+            result.color = false;
+        } else {
+            std.debug.print("Error: Unknown argument \"{s}\"\n", .{arg});
+            std.process.exit(2);
+        }
     }
 
     if (result.nmines >= @as(u16, result.width) * @as(u16, result.height)) {
-        try std.io.getStdErr().writer().print(
-            "{s}: there must be less mines than places for mines\n",
-            .{ std.process.parse_result.args().nextPosix().? });
-        std.os.exit(2);
+        std.debug.print("Error: there must be less mines than places for mines\n", .{});
+        std.process.exit(2);
     }
 
     return result;

--- a/src/argparser.zig
+++ b/src/argparser.zig
@@ -61,7 +61,10 @@ pub fn parse(allocator: std.mem.Allocator) !Args {
                 std.process.exit(2);
             }
             const mineCount = args[i];
-            result.nmines = try std.fmt.parseUnsigned(u16, mineCount, 10);
+            result.nmines = std.fmt.parseUnsigned(u16, mineCount, 10) catch {
+                std.debug.print("Error: Invalid number of mines\n", .{});
+                std.process.exit(2);
+            };
         } else if (std.mem.eql(u8, arg, "-a") or std.mem.eql(u8, arg, "--ascii-only")) {
             result.characters = cursesui.ascii_characters;
         } else if (std.mem.eql(u8, arg, "-c") or std.mem.eql(u8, arg, "--no-colors")) {

--- a/src/core.zig
+++ b/src/core.zig
@@ -24,9 +24,9 @@ pub const Game = struct {
     nmines: u16,
     status: GameStatus,
     mines_added: bool,
-    rnd: *const std.rand.Random,
+    rnd: std.Random,
 
-    pub fn init(allocator: std.mem.Allocator, width: u8, height: u8, nmines: u16, rnd: *const std.rand.Random) !Game {
+    pub fn init(allocator: std.mem.Allocator, width: u8, height: u8, nmines: u16, rnd: std.Random) !Game {
         // in the beginning, there are width*height squares, but the mines are
         // added when the user has already opened one of them, otherwise the
         // first square that the user opens could be a mine
@@ -88,7 +88,7 @@ pub const Game = struct {
             const nx_signed = neighbor[0];
             const ny_signed = neighbor[1];
             if (0 <= nx_signed and nx_signed < @as(i16, self.width) and 0 <= ny_signed and ny_signed < @as(i16, self.height)) {
-                res[i] = [2]u8{ @as(u8, nx_signed), @as(u8, ny_signed) };
+                res[i] = [2]u8{ @intCast(nx_signed), @intCast(ny_signed) };
                 i += 1;
             }
         }

--- a/src/core.zig
+++ b/src/core.zig
@@ -30,7 +30,7 @@ pub const Game = struct {
         // in the beginning, there are width*height squares, but the mines are
         // added when the user has already opened one of them, otherwise the
         // first square that the user opens could be a mine
-        std.debug.assert(@intCast(u16, width)*@intCast(u16, height) - 1 >= nmines);
+        std.debug.assert(@as(u16, width)*@as(u16, height) - 1 >= nmines);
 
         const map = try allocator.alloc([]Square, height);
         var nalloced: u8 = 0;
@@ -73,22 +73,22 @@ pub const Game = struct {
 
     fn getNeighbors(self: Game, x: u8, y: u8, res: [][2]u8) [][2]u8 {
         const neighbors = [_][2]i16{
-            [2]i16{@intCast(i16, x)-1, @intCast(i16, y)-1},
-            [2]i16{@intCast(i16, x)-1, @intCast(i16, y)  },
-            [2]i16{@intCast(i16, x)-1, @intCast(i16, y)+1},
-            [2]i16{@intCast(i16, x),   @intCast(i16, y)+1},
-            [2]i16{@intCast(i16, x)+1, @intCast(i16, y)+1},
-            [2]i16{@intCast(i16, x)+1, @intCast(i16, y)  },
-            [2]i16{@intCast(i16, x)+1, @intCast(i16, y)-1},
-            [2]i16{@intCast(i16, x),   @intCast(i16, y)-1},
+            [2]i16{@as(i16, x)-1, @as(i16, y)-1},
+            [2]i16{@as(i16, x)-1, @as(i16, y)  },
+            [2]i16{@as(i16, x)-1, @as(i16, y)+1},
+            [2]i16{@as(i16, x),   @as(i16, y)+1},
+            [2]i16{@as(i16, x)+1, @as(i16, y)+1},
+            [2]i16{@as(i16, x)+1, @as(i16, y)  },
+            [2]i16{@as(i16, x)+1, @as(i16, y)-1},
+            [2]i16{@as(i16, x),   @as(i16, y)-1},
         };
         var i: u8 = 0;
 
         for (neighbors) |neighbor| {
             const nx_signed = neighbor[0];
             const ny_signed = neighbor[1];
-            if (0 <= nx_signed and nx_signed < @intCast(i16, self.width) and 0 <= ny_signed and ny_signed < @intCast(i16, self.height)) {
-                res[i] = [2]u8{ @intCast(u8, nx_signed), @intCast(u8, ny_signed) };
+            if (0 <= nx_signed and nx_signed < @as(i16, self.width) and 0 <= ny_signed and ny_signed < @as(i16, self.height)) {
+                res[i] = [2]u8{ @as(u8, nx_signed), @as(u8, ny_signed) };
                 i += 1;
             }
         }

--- a/src/core.zig
+++ b/src/core.zig
@@ -259,24 +259,3 @@ pub const Game = struct {
         self.map[y][x].flagged = !self.map[y][x].flagged;
     }
 };
-
-
-test "init deinit open getSquareInfo" {
-    const allocator = std.debug.global_allocator;
-    const expect = std.testing.expect;
-    var default_prng = std.rand.Xoroshiro128.init(42);
-    const rnd = &default_prng.random;
-
-    var game = try Game.init(allocator, 10, 20, 5, rnd);
-    defer game.deinit();
-
-    expect(!game.getSquareInfo(1, 2).opened);
-    game.open(1, 2);
-    //game.debugDump();
-    expect(game.getSquareInfo(1, 2).opened);
-    expect(game.getSquareInfo(1, 2).n_mines_around == 0);
-    expect(game.getSquareInfo(9, 2).opened);
-    expect(game.getSquareInfo(9, 2).n_mines_around == 0);
-    expect(game.getSquareInfo(9, 3).opened);
-    expect(game.getSquareInfo(9, 3).n_mines_around == 1);
-}

--- a/src/curses.zig
+++ b/src/curses.zig
@@ -40,8 +40,8 @@ pub const Window = struct {
     }
 
     // TODO: don't use "legacy" functions like getmaxy()?
-    pub fn getmaxy(self: Window) u16 { return @intCast(u16, c.getmaxy(self.win)); }
-    pub fn getmaxx(self: Window) u16 { return @intCast(u16, c.getmaxx(self.win)); }
+    pub fn getmaxy(self: Window) u16 { return @as(u16, c.getmaxy(self.win)); }
+    pub fn getmaxx(self: Window) u16 { return @as(u16, c.getmaxx(self.win)); }
 
     pub fn attron(self: Window, attr: c_int) !void { _ = try checkError(c.wattron(self.win, attr)); }
     pub fn attroff(self: Window, attr: c_int) !void { _ = try checkError(c.wattroff(self.win, attr)); }
@@ -56,7 +56,7 @@ pub const A_STANDOUT = c.MY_A_STANDOUT;
 
 pub fn initscr(allocator: std.mem.Allocator) !Window {
     const res = c.initscr();
-    if (@ptrToInt(res) == 0) {
+    if (res == null) {
         return Error;
     }
     return Window{ .win = res, .allocator = allocator };
@@ -97,13 +97,13 @@ pub const ColorPair = struct {
     id: c_short,
 
     pub fn init(id: c_short, front: c_short, back: c_short) !ColorPair {
-        std.debug.assert(1 <= id and id < @intCast(c_short, color_pair_attrs.len));
+        std.debug.assert(1 <= id and id < @as(c_short, color_pair_attrs.len));
         _ = try checkError(c.init_pair(id, front, back));
         return ColorPair{ .id = id };
     }
 
     pub fn attr(self: ColorPair) c_int {
-        return color_pair_attrs[@intCast(usize, self.id)];
+        return color_pair_attrs[@as(usize, self.id)];
     }
 };
 

--- a/src/curses.zig
+++ b/src/curses.zig
@@ -34,14 +34,14 @@ pub const Window = struct {
     pub fn mvaddstr(self: Window, y: u16, x: u16, str: []const u8) !void {
         const cstr: []u8 = try self.allocator.alloc(u8, str.len + 1);
         defer self.allocator.free(cstr);
-        std.mem.copy(u8, cstr, str);
+        std.mem.copyForwards(u8, cstr, str);
         cstr[str.len] = 0;
         _ = try checkError(c.mvwaddstr(self.win, y, x, cstr.ptr));
     }
 
     // TODO: don't use "legacy" functions like getmaxy()?
-    pub fn getmaxy(self: Window) u16 { return @as(u16, c.getmaxy(self.win)); }
-    pub fn getmaxx(self: Window) u16 { return @as(u16, c.getmaxx(self.win)); }
+    pub fn getmaxy(self: Window) u16 { return @intCast(c.getmaxy(self.win)); }
+    pub fn getmaxx(self: Window) u16 { return @intCast(c.getmaxx(self.win)); }
 
     pub fn attron(self: Window, attr: c_int) !void { _ = try checkError(c.wattron(self.win, attr)); }
     pub fn attroff(self: Window, attr: c_int) !void { _ = try checkError(c.wattroff(self.win, attr)); }
@@ -103,7 +103,7 @@ pub const ColorPair = struct {
     }
 
     pub fn attr(self: ColorPair) c_int {
-        return color_pair_attrs[@as(usize, self.id)];
+        return color_pair_attrs[@intCast(self.id)];
     }
 };
 

--- a/src/cursesui.zig
+++ b/src/cursesui.zig
@@ -98,13 +98,13 @@ pub const Ui = struct {
             curses.COLOR_MAGENTA,
         };
         std.debug.assert(colors.len == self.number_attrs.len);
-        for (colors) |color, i| {
-            const pair = try curses.ColorPair.init(@intCast(c_short, i+1), color, curses.COLOR_BLACK);
+        for (colors, 0..) |color, i| {
+            const pair = try curses.ColorPair.init(@as(c_short, i+1), color, curses.COLOR_BLACK);
             self.number_attrs[i] = pair.attr();
         }
     }
 
-    fn getWidth(self: *const Ui) u16 { return (self.game.width * @intCast(u16, "|---".len)) + @intCast(u16, "|".len); }
+    fn getWidth(self: *const Ui) u16 { return (self.game.width * @as(u16, "|---".len)) + @as(u16, "|".len); }
     fn getHeight(self: *const Ui) u16 { return (self.game.height * 2) + 1; }
 
     fn drawLine(self: *const Ui, y: u16, xleft: u16, left: []const u8, mid: []const u8, right: []const u8, horiz: []const u8) !void {

--- a/src/cursesui.zig
+++ b/src/cursesui.zig
@@ -79,9 +79,7 @@ pub const Ui = struct {
 
     fn setupColors(self: *Ui, use_colors: bool) !void {
         if (!use_colors) {
-            for (self.number_attrs) |*ptr| {
-                ptr.* = 0;
-            }
+            @memset(&self.number_attrs, 0);
             return;
         }
 
@@ -99,7 +97,7 @@ pub const Ui = struct {
         };
         std.debug.assert(colors.len == self.number_attrs.len);
         for (colors, 0..) |color, i| {
-            const pair = try curses.ColorPair.init(@as(c_short, i+1), color, curses.COLOR_BLACK);
+            const pair = try curses.ColorPair.init(@intCast(i+1), color, curses.COLOR_BLACK);
             self.number_attrs[i] = pair.attr();
         }
     }
@@ -124,8 +122,8 @@ pub const Ui = struct {
     }
 
     fn drawGrid(self: *const Ui) !void {
-        var top: u16 = (self.window.getmaxy() - self.getHeight()) / 2;
-        var left: u16 = (self.window.getmaxx() - self.getWidth()) / 2;
+        const top: u16 = (self.window.getmaxy() - self.getHeight()) / 2;
+        const left: u16 = (self.window.getmaxx() - self.getWidth()) / 2;
 
         var gamey: u8 = 0;
         var y: u16 = top;

--- a/src/help.zig
+++ b/src/help.zig
@@ -81,7 +81,7 @@ fn drawText(window: curses.Window, key_bindings: []const KeyBinding, allocator: 
 
     var maxlen: u16 = 0;
     for (key_bindings) |kb| {
-        maxlen = std.math.max(maxlen, @intCast(u16, kb.key.len));
+        maxlen = std.math.max(maxlen, @as(u16, kb.key.len));
     }
 
     var y: u16 = 0;

--- a/src/help.zig
+++ b/src/help.zig
@@ -81,7 +81,9 @@ fn drawText(window: curses.Window, key_bindings: []const KeyBinding, allocator: 
 
     var maxlen: u16 = 0;
     for (key_bindings) |kb| {
-        maxlen = std.math.max(maxlen, @as(u16, kb.key.len));
+        if (kb.key.len > maxlen) {
+            maxlen = @intCast(kb.key.len);
+        }
     }
 
     var y: u16 = 0;


### PR DESCRIPTION
- Remove zig-clap dependency and rewrite argument parsing by hand
- Delete tests, for a few reasons:
    - Only 20 lines of existing tests
    - Not useful, most of the code is UI code and hard to test anyway
    - No real need to have tests in this project
- Generate a new `build.zig` with `zig.init` (contains a few manual edits)
- Various small changes